### PR TITLE
SqsClient should not be generic

### DIFF
--- a/src/main/java/com/bandwidth/sqs/client/SqsClientBuilder.java
+++ b/src/main/java/com/bandwidth/sqs/client/SqsClientBuilder.java
@@ -12,7 +12,7 @@ import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 
 import io.reactivex.functions.Function;
 
-public class SqsClientBuilder<T> {
+public class SqsClientBuilder {
     public static final int DEFAULT_RETRY_COUNT = 3;
     public static final AWSCredentialsProvider DEFAULT_CREDENTIALS_PROVIDER = new DefaultAWSCredentialsProviderChain();
     public static final AsyncHttpClient DEFAULT_ASYNC_HTTP_CLIENT = new DefaultAsyncHttpClient(
@@ -24,53 +24,28 @@ public class SqsClientBuilder<T> {
                     .build()
     );
 
-    public final Function<String, T> deserialize;
-    public final Function<T, String> serialize;
-
     private int retryCount = DEFAULT_RETRY_COUNT;
     private AWSCredentialsProvider credentialsProvider = DEFAULT_CREDENTIALS_PROVIDER;
     private AsyncHttpClient httpClient = DEFAULT_ASYNC_HTTP_CLIENT;
 
-    public SqsClientBuilder(Function<String, T> deserialize, Function<T, String> serialize) {
-        this.deserialize = deserialize;
-        this.serialize = serialize;
-    }
-
-    public SqsClientBuilder<T> retryCount(int retryCount) {
+    public SqsClientBuilder retryCount(int retryCount) {
         this.retryCount = retryCount;
         return this;
     }
 
-    public SqsClientBuilder<T> credentialsProvider(AWSCredentialsProvider credentialsProvider) {
+    public SqsClientBuilder credentialsProvider(AWSCredentialsProvider credentialsProvider) {
         this.credentialsProvider = credentialsProvider;
         return this;
     }
 
-    public SqsClientBuilder<T> httpClient(AsyncHttpClient asyncHttpClient) {
+    public SqsClientBuilder httpClient(AsyncHttpClient asyncHttpClient) {
         this.httpClient = asyncHttpClient;
         return this;
     }
 
-
-    /**
-     * Converts the builder to a different type by defining mapping functions between the original and new type
-     *
-     * @param map        Map from the original value, to the new value
-     * @param inverseMap Map from the new value, back to the original value
-     */
-    public <U> SqsClientBuilder<U> map(Function<T, U> map, Function<U, T> inverseMap) {
-        Function<String, U> stringMap = string -> map.apply(deserialize.apply(string));
-        Function<U, String> stringInverseMap = data -> serialize.apply(inverseMap.apply(data));
-        return new SqsClientBuilder<>(stringMap, stringInverseMap)
-                .retryCount(retryCount)
-                .credentialsProvider(credentialsProvider)
-                .httpClient(httpClient);
-    }
-
-
-    public SqsClient<T> build() {
+    public SqsClient build() {
         SqsRequestSender requestSender = new RetryingSqsRequestSender(retryCount,
                 new BaseSqsRequestSender(httpClient, credentialsProvider));
-        return new SqsClient<>(requestSender, deserialize, serialize);
+        return new SqsClient(requestSender);
     }
 }

--- a/src/main/java/com/bandwidth/sqs/queue/SqsQueue.java
+++ b/src/main/java/com/bandwidth/sqs/queue/SqsQueue.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import io.reactivex.Completable;
 import io.reactivex.Single;
+import io.reactivex.functions.Function;
 
 public interface SqsQueue<T> extends MessagePublisher<T> {
 
@@ -25,6 +26,10 @@ public interface SqsQueue<T> extends MessagePublisher<T> {
     Completable changeMessageVisibility(String receiptHandle, Duration newVisibility);
 
     Completable setAttributes(MutableSqsQueueAttributes attributes);
+
+    default <U> SqsQueue<U> map(Function<T, U> map, Function<U, T> inverseMap) {
+        return new MappingSqsQueue<>(this, map, inverseMap);
+    }
 
     default Single<List<SqsMessage<T>>> receiveMessages(int maxMessages, Duration waitTime, Duration
             visibilityTimeout) {

--- a/src/test/java/com/bandwidth/sqs/client/SqsClientBuilderTest.java
+++ b/src/test/java/com/bandwidth/sqs/client/SqsClientBuilderTest.java
@@ -18,18 +18,11 @@ public class SqsClientBuilderTest {
 
     @Test
     public void testBuilder() {
-        SqsClientBuilder<String> stringClientBuilder = SqsClient.builder()
+        SqsClientBuilder stringClientBuilder = SqsClient.builder()
                 .credentialsProvider(credentialsProviderMock)
                 .httpClient(asyncHttpClientMock)
                 .retryCount(RETRY_COUNT);
-
-        Function<Integer, String> serialize = (n) -> Integer.toString(n);
-        SqsClientBuilder<Integer> intBuilder = stringClientBuilder.map(Integer::parseInt, serialize);
-
-        SqsClient<String> stringClient = stringClientBuilder.build();
-        SqsClient<Integer> intClient = intBuilder.build();
-
-        assertThat(stringClient).isNotNull();
-        assertThat(intClient).isNotNull();
+        SqsClient client = stringClientBuilder.build();
+        assertThat(client).isNotNull();
     }
 }

--- a/src/test/java/com/bandwidth/sqs/client/SqsClientTest.java
+++ b/src/test/java/com/bandwidth/sqs/client/SqsClientTest.java
@@ -21,7 +21,6 @@ import com.bandwidth.sqs.action.sender.SqsRequestSender;
 import org.junit.Test;
 
 import io.reactivex.Single;
-import io.reactivex.functions.Function;
 
 public class SqsClientTest {
     private static final AmazonSQSException QUEUE_ALREADY_EXISTS_EXCEPTION = new AmazonSQSException("");
@@ -33,12 +32,10 @@ public class SqsClientTest {
             .name(QUEUE_NAME)
             .region(Regions.US_EAST_1)
             .build();
-    private static final Function<String, String> NOOP_SERIALIZER = (str) -> str;
 
     private final SqsRequestSender requestSenderMock = mock(SqsRequestSender.class);
 
-    private final SqsClient<String> client =
-            new SqsClient<>(requestSenderMock, NOOP_SERIALIZER, NOOP_SERIALIZER);
+    private final SqsClient client = new SqsClient(requestSenderMock);
 
     public SqsClientTest() {
         QUEUE_ALREADY_EXISTS_EXCEPTION.setErrorCode(QUEUE_ALREADY_EXISTS);


### PR DESCRIPTION
`SqsClient` shouldn't actually be generic. You should be able to have a single client, and create queues of different types from that client. By default, the `SqsClient` will return `SqsQueue<String>` and the queue now contains a `map` function to change the queue type.