### PR TITLE
improve retry

### DIFF
--- a/src/main/java/com/bandwidth/sqs/action/sender/RetryingSqsRequestSender.java
+++ b/src/main/java/com/bandwidth/sqs/action/sender/RetryingSqsRequestSender.java
@@ -25,7 +25,7 @@ public class RetryingSqsRequestSender implements SqsRequestSender {
                         return false;
                     }
                     if (error instanceof AmazonSQSException) {
-                        return ((AmazonSQSException) error).getErrorType() == AmazonServiceException.ErrorType.Service;
+                        return ((AmazonSQSException) error).getErrorType() != AmazonServiceException.ErrorType.Client;
                     }
                     return true;
                 }).subscribeWith(SingleSubject.create());//convert to Hot single

--- a/src/main/java/com/bandwidth/sqs/client/SqsClient.java
+++ b/src/main/java/com/bandwidth/sqs/client/SqsClient.java
@@ -63,9 +63,8 @@ public class SqsClient {
      */
     public Single<SqsQueue<String>> upsertQueue(SqsQueueConfig queueConfig, SqsQueueClientConfig clientConfig) {
         CreateQueueAction action = new CreateQueueAction(queueConfig);
-        Single<SqsQueue<String>> output = requestSender.sendRequest(action).map(createQueueResult -> {
-            return new BufferedStringSqsQueue(createQueueResult.getQueueUrl(), requestSender, clientConfig);
-        });
+        Single<SqsQueue<String>> output = requestSender.sendRequest(action)
+                .map(createQueueResult -> getQueueFromUrl(createQueueResult.getQueueUrl(), clientConfig));
         return output.onErrorResumeNext((err) -> {
             if (err instanceof AmazonSQSException) {
                 AmazonSQSException awsException = (AmazonSQSException) err;

--- a/src/main/java/com/bandwidth/sqs/queue/RetryingSqsQueue.java
+++ b/src/main/java/com/bandwidth/sqs/queue/RetryingSqsQueue.java
@@ -59,7 +59,7 @@ public class RetryingSqsQueue<T> implements SqsQueue<T> {
             return false;
         }
         if (error instanceof AmazonSQSException) {
-            return ((AmazonSQSException) error).getErrorType() == AmazonServiceException.ErrorType.Service;
+            return ((AmazonSQSException) error).getErrorType() != AmazonServiceException.ErrorType.Client;
         }
         return true;
     }


### PR DESCRIPTION
2 major changes
1 - When a queue is upserted, if it already exists this had a different code path to return the SqsQueue, which wasn't getting wrapped in the retrying SqsQueue. This was fixed
2 - Some requests that received a 503 did not contain a correct ErrorType. The retry logic only retries if the error was not the client's fault, and since some ErrorType's were "Unknown" these were not retried. This is also now fixed.