### PR TITLE
Do release permit when handler errors

### DIFF
--- a/src/main/java/com/bandwidth/sqs/consumer/SqsConsumer.java
+++ b/src/main/java/com/bandwidth/sqs/consumer/SqsConsumer.java
@@ -278,8 +278,8 @@ public class SqsConsumer<T> {
             acknowledger.ignore();
         } else {
             Completable.fromRunnable(() -> handler.handleMessage(message, acknowledger))
+                    .onErrorResumeNext(throwable -> Completable.fromAction(acknowledger::ignore))
                     .andThen(acknowledger.getAckMode())
-                    .onErrorReturnItem(AckMode.IGNORE)
                     .subscribe((ackMode) -> {
                         if (ackMode.isSuccessful()) {
                             failureAverage.addData(MESSAGE_SUCCESS);


### PR DESCRIPTION
If the `ConsumerHandler` throws an exception in it's `handleMessage` method, we treat the message as `IGNORE`d. However, this only concerns the `ackMode` and not the `ackingComplete`; it is the acking completable which determines whether the permit gets released. Since we are assuming that the message has been dropped, we can acquire another permit. By actually calling the `ignore` method on the acknowledger, we ensure that its ackMode is `IGNORE` and that its acking is also complete.

Issue: if in fact the handler method started some other thread before erroring, and that thread never terminates, then that would still be a thread leak; however, without this change, in that case there would still be a thread leak _and_ the consumer would run out of permits. Which is worse?