### PR TITLE
Change KeyedTaskBuffer execution model to not hold locks while executing tasks.

### DIFF
--- a/src/main/java/com/bandwidth/sqs/queue/buffer/KeyedTaskBuffer.java
+++ b/src/main/java/com/bandwidth/sqs/queue/buffer/KeyedTaskBuffer.java
@@ -1,8 +1,5 @@
 package com.bandwidth.sqs.queue.buffer;
 
-
-import com.google.common.annotations.VisibleForTesting;
-
 import com.bandwidth.sqs.queue.buffer.task.Task;
 
 import java.time.Duration;
@@ -10,8 +7,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A buffer that buffers individual data, collecting it in bucket by key, then running a task to batch process the data
@@ -20,64 +19,82 @@ import java.util.TimerTask;
  * @param <D> Data
  */
 public class KeyedTaskBuffer<K, D> {
-    private Timer timer = new Timer();
+    private final ScheduledExecutorService scheduledExecutorService;
+    private final ExecutorService taskExecutorService;
     private final int maxBufferSize;
     private final Duration maxWait;
     private final Map<K, List<D>> buffers = new HashMap<>();
     private final Task<K, D> task;
 
+    /**
+     * Construct a KeyedTaskBuffer with a default execution policy:
+     *     A single threaded ScheduledThreadPool for buffer timeout invocation
+     *     A single threaded ExecutorService for that tasks will be submitted to
+     */
     public KeyedTaskBuffer(int maxBufferSize, Duration maxWait, Task<K, D> task) {
+        this(Executors.newScheduledThreadPool(1), Executors.newSingleThreadExecutor(),
+                maxBufferSize, maxWait, task);
+    }
+
+    /**
+     * Construct a KeyedTaskBuffer with all parameters
+     * @param scheduledExecutorService - The executor used for buffer timeout invocation
+     * @param taskExecutorService - The executor used for invoking tasks when the buffer is flushed
+     * @param maxBufferSize - The maximum amount of task data to hold before flushing the batch and executing it
+     * @param maxWait - The maximum amount of time to hold a batch before flushing it regardless of size
+     * @param task - The task that executes the batched data
+     */
+    public KeyedTaskBuffer(ScheduledExecutorService scheduledExecutorService, ExecutorService taskExecutorService,
+                           int maxBufferSize, Duration maxWait, Task<K, D> task) {
+        this.scheduledExecutorService = scheduledExecutorService;
+        this.taskExecutorService = taskExecutorService;
         this.maxBufferSize = maxBufferSize;
         this.maxWait = maxWait;
         this.task = task;
     }
 
-    public synchronized void addData(K key, D data) {
+
+    /**
+     * Add task data to a keyed buffer.  If the buffer is full the batch will be submitted immediately
+     * to the taskExecutorService.  Otherwise the batch will be submitted when the maxWait timeout occurs
+     * @param key - Task Key.  Tasks with common keys are batched
+     * @param data - Task Data
+     */
+    public synchronized void addData(final K key, D data) {
         List<D> buffer = buffers.get(key);
         if (buffer == null) {
-            TimerTask timerTask = new TimerExpiredTask(key);
             buffer = new ArrayList<>();
             buffers.put(key, buffer);
-            timer.schedule(timerTask, maxWait.toMillis());
+
+            scheduledExecutorService.schedule(() ->{
+                try {
+                    processBatchIfNeeded(key, true);
+                }
+                catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }, maxWait.toMillis(), TimeUnit.MILLISECONDS);
         }
         buffer.add(data);
         processBatchIfNeeded(key, false);
     }
 
-    private synchronized void processBatchIfNeeded(K key, boolean expired) {
+    /**
+     * Process a batch of tasks if the batch is full OR if the timeout has occurred
+     * @param key The task key
+     * @param expired this is true when invoked from the scheduler thread and false when invoked
+     *                after adding a new value to the batch
+     */
+    private synchronized void processBatchIfNeeded(final K key, boolean expired) {
         if (!buffers.containsKey(key)) {
             return;
         }
-        List<D> buffer = buffers.get(key);
+        final List<D> buffer = buffers.get(key);
         boolean isMaxSize = buffer.size() >= maxBufferSize;
         if (isMaxSize || expired) {
             buffers.remove(key);
-            task.run(key, buffer);
+            //The task is ready, submit for execution on a thread that is not holding the lock
+            taskExecutorService.submit(() -> task.run(key, buffer));
         }
-    }
-
-    /**
-     * Internal task that runs when data in a buffers has exceeded 'maxWaitMillis'
-     */
-    private class TimerExpiredTask extends TimerTask {
-        private final K key;
-
-        public TimerExpiredTask(K key) {
-            this.key = key;
-        }
-
-        @Override
-        public void run() {
-            try {
-                processBatchIfNeeded(key, true);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-    }
-
-    @VisibleForTesting
-    void setTimer(Timer timer) {
-        this.timer = timer;
     }
 }

--- a/src/main/java/com/bandwidth/sqs/queue/buffer/KeyedTaskBuffer.java
+++ b/src/main/java/com/bandwidth/sqs/queue/buffer/KeyedTaskBuffer.java
@@ -98,9 +98,9 @@ public class KeyedTaskBuffer<K, D> {
      * @param key The task key
      */
     private void processExpiredBatch(final K key) {
-        List<D> batch = fetchAndRemoveBatchIfReady(key, true);
-        if (batch != null) {
-            task.run(key, batch);
+        List<D> readyBatch = fetchAndRemoveBatchIfReady(key, true);
+        if (readyBatch != null) {
+            task.run(key, readyBatch);
         }
     }
 
@@ -110,7 +110,7 @@ public class KeyedTaskBuffer<K, D> {
      * @param key The task key
      * @param expired this is true when invoked from the scheduler thread and false when invoked
      *                after adding a new value to the batch
-     * @return
+     * @return A list of task data if a batch is ready, otherwise Null
      */
     private synchronized List<D> fetchAndRemoveBatchIfReady(K key, boolean expired) {
         if (!buffers.containsKey(key)) {
@@ -129,6 +129,7 @@ public class KeyedTaskBuffer<K, D> {
 
     @PreDestroy
     public void shutdown() {
+        LOG.info("Shutting down keyed task buffer");
         this.scheduledExecutorService.shutdown();
     }
 }

--- a/src/test/java/com/bandwidth/sqs/queue/buffer/KeyedTaskBufferTest.java
+++ b/src/test/java/com/bandwidth/sqs/queue/buffer/KeyedTaskBufferTest.java
@@ -110,5 +110,15 @@ public class KeyedTaskBufferTest {
         //unit test can only finish if this is completed
         completedSecondRun.timeout(1000, TimeUnit.MILLISECONDS).blockingAwait();
     }
+
+    @Test
+    public void testShutdown() {
+        KeyedTaskBuffer<String, Integer> taskBuffer = new KeyedTaskBuffer<>(schedulerMock,
+                MAX_BUFFER_SIZE, MAX_WAIT_MILLIS_100, task);
+
+        taskBuffer.shutdown();
+        verify(schedulerMock).shutdown();
+    }
 }
+
 

--- a/src/test/java/com/bandwidth/sqs/queue/buffer/KeyedTaskBufferTest.java
+++ b/src/test/java/com/bandwidth/sqs/queue/buffer/KeyedTaskBufferTest.java
@@ -2,6 +2,7 @@ package com.bandwidth.sqs.queue.buffer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -11,9 +12,8 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.Duration;
-import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -38,20 +38,25 @@ public class KeyedTaskBufferTest {
             MAX_WAIT_MILLIS_100, task
     );
 
-    private final Timer timerMock = mock(Timer.class);
+    private final ScheduledExecutorService schedulerMock = mock(ScheduledExecutorService.class);
+    private final ExecutorService executorMock = mock(ExecutorService.class);
 
-    private final ArgumentCaptor<TimerTask> timerTaskCaptor = ArgumentCaptor.forClass(TimerTask.class);
+    private final ArgumentCaptor<Runnable> scheduledTaskCaptor = ArgumentCaptor.forClass(Runnable.class);
+    private final ArgumentCaptor<Runnable> executedTaskCaptor = ArgumentCaptor.forClass(Runnable.class);
 
     @Test
     public void testBufferFull() {
-        KeyedTaskBuffer<String, Integer> taskBuffer =
-                new KeyedTaskBuffer<>(MAX_BUFFER_SIZE, MAX_WAIT_MILLIS_INFINITE, task);
+        KeyedTaskBuffer<String, Integer> taskBuffer = new KeyedTaskBuffer<>(schedulerMock, executorMock,
+                MAX_BUFFER_SIZE, MAX_WAIT_MILLIS_INFINITE, task);
 
         taskBuffer.addData(KEY_A, 1); //creates new 'A' buffer, not full yet
         taskBuffer.addData(KEY_A, 2); //2nd element of 'A' buffer, not full yet
         taskBuffer.addData(KEY_B, 4); //creates new 'B' buffer, not full yet
         taskBuffer.addData(KEY_A, 8); //fills 'A' buffer, A task runner will run
         taskBuffer.addData(KEY_A, 16); //start of next 'A' buffer, not full yet
+
+        verify(executorMock).submit(executedTaskCaptor.capture());
+        executedTaskCaptor.getValue().run();
 
         assertThat(count).isEqualTo(1 + 2 + 8);
     }
@@ -65,25 +70,36 @@ public class KeyedTaskBufferTest {
     }
 
     @Test
-    public void testBufferTimeout() throws InterruptedException {
-        KeyedTaskBuffer<String, Integer> taskBuffer = new KeyedTaskBuffer<>(MAX_BUFFER_SIZE, MAX_WAIT_MILLIS_0, task);
-        taskBuffer.setTimer(timerMock);
+    public void testBufferTimeout() {
+        KeyedTaskBuffer<String, Integer> taskBuffer = new KeyedTaskBuffer<>(schedulerMock, executorMock,
+                MAX_BUFFER_SIZE, MAX_WAIT_MILLIS_0, task);
+
         taskBuffer.addData(KEY_A, 1);
         taskBuffer.addData(KEY_A, 2);
-        verify(timerMock).schedule(timerTaskCaptor.capture(), anyLong());
-        timerTaskCaptor.getValue().run();
+
+        verify(schedulerMock).schedule(scheduledTaskCaptor.capture(), anyLong(), eq(TimeUnit.MILLISECONDS));
+        scheduledTaskCaptor.getValue().run();
+
+        verify(executorMock).submit(executedTaskCaptor.capture());
+        executedTaskCaptor.getValue().run();
+
         assertThat(count).isEqualTo(1 + 2);
     }
 
     @Test
-    public void testBufferTimeoutAfterEmptied() throws InterruptedException {
-        KeyedTaskBuffer<String, Integer> taskBuffer = new KeyedTaskBuffer<>(MAX_BUFFER_SIZE, MAX_WAIT_MILLIS_0, task);
-        taskBuffer.setTimer(timerMock);
+    public void testBufferTimeoutAfterEmptied() {
+        KeyedTaskBuffer<String, Integer> taskBuffer = new KeyedTaskBuffer<>(schedulerMock, executorMock,
+                MAX_BUFFER_SIZE, MAX_WAIT_MILLIS_0, task);
         taskBuffer.addData(KEY_A, 1);
         taskBuffer.addData(KEY_A, 2);
         taskBuffer.addData(KEY_A, 3);
-        verify(timerMock).schedule(timerTaskCaptor.capture(), anyLong());
-        timerTaskCaptor.getValue().run();
+
+        verify(schedulerMock).schedule(scheduledTaskCaptor.capture(), anyLong(), eq(TimeUnit.MILLISECONDS));
+        scheduledTaskCaptor.getValue().run();
+
+        verify(executorMock).submit(executedTaskCaptor.capture());
+        executedTaskCaptor.getValue().run();
+
         assertThat(count).isEqualTo(1 + 2 + 3);
     }
 


### PR DESCRIPTION
This should provide a pretty good performance boost for tasks that take some time to execute (perhaps by making a Redis request).